### PR TITLE
Update booruextractor.js at line 144

### DIFF
--- a/booruextractor.js
+++ b/booruextractor.js
@@ -141,5 +141,5 @@ function CleanFileName(name) {
 }
 
 function CleanDirectory(name) {
-    return name.replace(/[<>"|?*\x00-\x1F]/gi, '_'); // Strip any special characters
+    return name.replace(/[<>:"\/\\|?*\x00-\x1F]/gi, '_'); // Strip any special characters
 }


### PR DESCRIPTION
function CleanDirectory  - ":" is an invalid character in Windows, "\" and "/" cause unexpected creation of subdirectories. 
Basically changing the RegEx like the one in CleanName should work (it did in my previous private fork before Mozilla required addon signing)